### PR TITLE
Allow iterables to be digested and signed

### DIFF
--- a/nkms/crypto/keypairs.py
+++ b/nkms/crypto/keypairs.py
@@ -1,7 +1,9 @@
 import msgpack
+import sha3
 from random import SystemRandom
 from py_ecc.secp256k1 import N, privtopub, ecdsa_raw_sign, ecdsa_raw_recover
 from npre import umbral
+from typing import Iterable
 
 
 class EncryptingKeypair(object):
@@ -124,6 +126,23 @@ class SigningKeypair(object):
         r = int.from_bytes(sig[1], byteorder='big')
         s = int.from_bytes(sig[2], byteorder='big')
         return (v, r, s)
+
+    def digest(self, data: Iterable) -> bytes:
+        """
+        Accepts an iterable containing bytes and digests it.
+
+        :param Iterable data: Data to digest
+
+        :rtype: bytes
+        :return: bytestring of digested data
+        """
+        if type(data) == bytes:
+            return sha3.keccak_256(data).digest()
+
+        hash = sha3.keccak_256()
+        for item in data:
+            hash.update(item)
+        return hash.digest()
 
     def sign(self, msghash):
         """

--- a/nkms/crypto/keypairs.py
+++ b/nkms/crypto/keypairs.py
@@ -127,21 +127,18 @@ class SigningKeypair(object):
         s = int.from_bytes(sig[2], byteorder='big')
         return (v, r, s)
 
-    def digest(self, data: Iterable) -> bytes:
+    def digest(self, *args):
         """
         Accepts an iterable containing bytes and digests it.
 
-        :param Iterable data: Data to digest
+        :param bytes *args: Data to hash
 
         :rtype: bytes
         :return: bytestring of digested data
         """
-        if type(data) == bytes:
-            return sha3.keccak_256(data).digest()
-
         hash = sha3.keccak_256()
-        for item in data:
-            hash.update(item)
+        for arg in args:
+            hash.update(arg)
         return hash.digest()
 
     def sign(self, msghash):

--- a/nkms/crypto/keyring.py
+++ b/nkms/crypto/keyring.py
@@ -109,12 +109,12 @@ class KeyRing(object):
         """
         Signs a message and returns a signature with the keccak hash.
 
-        :param bytes message: Message to sign in bytes
+        :param Iterable message: Message to sign in an iterable of bytes
 
         :rtype: bytestring
         :return: Signature of message
         """
-        msg_digest = sha3.keccak_256(message).digest()
+        msg_digest = self.sig_keypair.digest(message)
         return self.sig_keypair.sign(msg_digest)
 
     def verify(self, message, signature, pubkey=None):

--- a/tests/crypto/test_keypairs.py
+++ b/tests/crypto/test_keypairs.py
@@ -33,18 +33,8 @@ class TestSigningKeypair(unittest.TestCase):
                                            pubkey=self.keypair_a.pub_key)
         self.assertTrue(verify_sig)
 
-    def test_digest_iterable(self):
-        # Test digest equality
-        digest_a = self.keypair_a.digest([self.msg])
-        digest_b = self.keypair_a.digest((self.msg))
-        digest_c = self.keypair_a.digest(self.msg)
-
-        self.assertEqual(digest_a, digest_b)
-        self.assertEqual(digest_a, digest_c)
-        self.assertEqual(digest_b, digest_c)
-
-        # Test multiple items
-        digest_a = self.keypair_a.digest([b'foo', b'bar'])
+    def test_digest(self):
+        digest_a = self.keypair_a.digest(b'foo', b'bar')
         digest_b = self.keypair_a.digest(b'foobar')
 
         self.assertEqual(digest_a, digest_b)

--- a/tests/crypto/test_keypairs.py
+++ b/tests/crypto/test_keypairs.py
@@ -33,6 +33,22 @@ class TestSigningKeypair(unittest.TestCase):
                                            pubkey=self.keypair_a.pub_key)
         self.assertTrue(verify_sig)
 
+    def test_digest_iterable(self):
+        # Test digest equality
+        digest_a = self.keypair_a.digest([self.msg])
+        digest_b = self.keypair_a.digest((self.msg))
+        digest_c = self.keypair_a.digest(self.msg)
+
+        self.assertEqual(digest_a, digest_b)
+        self.assertEqual(digest_a, digest_c)
+        self.assertEqual(digest_b, digest_c)
+
+        # Test multiple items
+        digest_a = self.keypair_a.digest([b'foo', b'bar'])
+        digest_b = self.keypair_a.digest(b'foobar')
+
+        self.assertEqual(digest_a, digest_b)
+
 
 class TestEncryptingKeypair(unittest.TestCase):
     def setUp(self):

--- a/tests/test_network_actors.py
+++ b/tests/test_network_actors.py
@@ -1,4 +1,5 @@
 import asyncio
+import unittest
 
 from nkms.characters import Ursula, Alice
 from nkms.crypto.keyring import KeyRing
@@ -44,6 +45,7 @@ def test_alice_has_ursulas_public_key_and_uses_it_to_encode_policy_payload():
     policy_group.transmit(networky_stuff)
 
 
+@unittest.skip(reason="Work in progress")
 def test_alice_finds_ursula():
     event_loop = asyncio.new_event_loop()
     asyncio.set_event_loop(event_loop)


### PR DESCRIPTION
### What this does:
1. Allows iterable objects to be passed instead of just expecting plain `bytes` objects.

2. Adds a `digest` method to `SigningKeypair` that accepts an `Iterable` as `data`.
    1. If `data` is of `bytes` type, then it just hashes like normal.
    2. If `data` is not `bytes` but is an `Iterable`, then each item within it is updated into the digest.