### PR TITLE
Implement SigningPower

### DIFF
--- a/nkms/characters.py
+++ b/nkms/characters.py
@@ -2,7 +2,7 @@ from kademlia.network import Server
 
 from nkms.crypto import api
 from nkms.crypto.constants import NOT_SIGNED, NO_DECRYPTION_PERFORMED
-from nkms.crypto.powers import CryptoPower, SigningKeypair, EncryptingPower
+from nkms.crypto.powers import CryptoPower, SigningPower, EncryptingPower
 from nkms.network.server import NuCypherDHTServer, NuCypherSeedOnlyDHTServer
 
 
@@ -152,7 +152,7 @@ class Character(object):
 
 class Alice(Character):
     _server_class = NuCypherSeedOnlyDHTServer
-    _default_crypto_powerups = [SigningKeypair, EncryptingPower]
+    _default_crypto_powerups = [SigningPower, EncryptingPower]
 
     def find_best_ursula(self):
         # TODO: Right now this just finds the nearest node and returns its ip and port.  Make it do something useful.
@@ -174,9 +174,9 @@ class Alice(Character):
 
 
 class Bob(Character):
-    _default_crypto_powerups = [SigningKeypair, EncryptingPower]
+    _default_crypto_powerups = [SigningPower, EncryptingPower]
 
 
 class Ursula(Character):
     _server_class = NuCypherDHTServer
-    _default_crypto_powerups = [SigningKeypair, EncryptingPower]
+    _default_crypto_powerups = [SigningPower, EncryptingPower]

--- a/nkms/crypto/powers.py
+++ b/nkms/crypto/powers.py
@@ -101,13 +101,13 @@ class CryptoPowerUp(object):
 class SigningPower(CryptoPowerUp):
     confers_public_key = True
 
-    def __init__(self, keypair: keypairs.keypairs.SigningKeypair = None):
+    def __init__(self, keypair: keypairs.SigningKeypair = None):
         """
         Initializes a SigningPower object for CryptoPower.
         """
         self.keypair = keypair or keypairs.SigningKeypair()
         self.priv_key = self.keypair.privkey
-        self.pub_key = self.real_keypair.pubkey
+        self.pub_key = self.keypair.pubkey
 
     def sign(self, msghash):
         """

--- a/nkms/crypto/powers.py
+++ b/nkms/crypto/powers.py
@@ -101,12 +101,13 @@ class CryptoPowerUp(object):
 class SigningPower(CryptoPowerUp):
     confers_public_key = True
 
-    def __init__(self, keypair=None):  # TODO: Pretty much move this __init__ to SigningPower
-
-        self.real_keypair = keypair or RealSigingKeypair()  # Total throwaway line - this will not be "real_keypair" because this will be in SigningPower
-        self.real_keypair.gen_privkey()
-
-        self.priv_key, self.pub_key = self.real_keypair.privkey, self.real_keypair.pubkey
+    def __init__(self, keypair: keypairs.keypairs.SigningKeypair = None):
+        """
+        Initializes a SigningPower object for CryptoPower.
+        """
+        self.keypair = keypair or keypairs.SigningKeypair()
+        self.priv_key = self.keypair.privkey
+        self.pub_key = self.real_keypair.pubkey
 
     def sign(self, msghash):
         """
@@ -135,7 +136,7 @@ class EncryptingPower(CryptoPowerUp):
         Initalizes an EncryptingPower object for CryptoPower.
         """
 
-        self.keypair = keypair or EncryptingKeypair()
+        self.keypair = keypair or keypairs.EncryptingKeypair()
         self.priv_key = self.keypair.privkey
         self.pub_key = self.keypair.pubkey
 

--- a/nkms/crypto/powers.py
+++ b/nkms/crypto/powers.py
@@ -111,17 +111,13 @@ class SigningPower(CryptoPowerUp):
 
     def sign(self, msghash):
         """
-        TODO: Use crypto API sign()
+        Signs a hashed message and returns a signature.
 
-        Signs a hashed message and returns a msgpack'ed v, r, and s.
+        :param msghash: The hashed message to sign
 
-        :param bytes msghash: Hash of the message
-
-        :rtype: Bytestring
-        :return: Msgpacked bytestring of v, r, and s (the signature)
+        :return: Signature in bytes
         """
-        v, r, s = API.ecdsa_sign(msghash, self.priv_key)
-        return API.ecdsa_gen_sig(v, r, s)
+        return self.keypair.sign(msghash)
 
     def public_key(self):
         return self.pub_key

--- a/nkms/crypto/powers.py
+++ b/nkms/crypto/powers.py
@@ -48,7 +48,7 @@ class CryptoPower(object):
         try:
             # TODO: Turn this into an ID lookup on a KeyStore.
             return self._power_ups[
-                keypairs.SigningKeypair].pub_key
+                SigningPower].pub_key
         except KeyError:
             raise NoSigningPower
 
@@ -56,7 +56,7 @@ class CryptoPower(object):
         try:
             # TODO: Turn this into an ID lookup on a KeyStore.
             return API.ecdsa_bytes2pub(self._power_ups[
-                                           keypairs.SigningKeypair].pub_key)
+                                           SigningPower].pub_key)
         except KeyError:
             raise NoSigningPower
 
@@ -68,7 +68,7 @@ class CryptoPower(object):
         :return: Signature of message
         """
         try:
-            sig_keypair = self._power_ups[keypairs.SigningKeypair]
+            sig_keypair = self._power_ups[SigningPower]
         except KeyError:
             raise NoSigningPower
         msg_digest = b"".join(API.keccak_digest(m) for m in messages)

--- a/nkms/crypto/powers.py
+++ b/nkms/crypto/powers.py
@@ -94,7 +94,7 @@ class CryptoPowerUp(object):
     confers_public_key = False
 
 
-class SigningKeypair(CryptoPowerUp):
+class SigningPower(CryptoPowerUp):
     confers_public_key = True
 
     def __init__(self, keypair=None):  # TODO: Pretty much move this __init__ to SigningPower

--- a/nkms/crypto/powers.py
+++ b/nkms/crypto/powers.py
@@ -2,7 +2,6 @@ from typing import Iterable, List, Tuple
 
 from nkms.crypto import api as API
 from nkms.keystore import keypairs
-from nkms.keystore.keypairs import SigningKeypair as RealSigingKeypair, EncryptingKeypair
 
 
 class PowerUpError(TypeError):
@@ -20,7 +19,8 @@ class NoEncryptingPower(PowerUpError):
 class CryptoPower(object):
     def __init__(self, power_ups=[]):
         self._power_ups = {}
-        self.public_keys = {}  # TODO: The keys here will actually be IDs for looking up in a KeyStore.
+        # TODO: The keys here will actually be IDs for looking up in a KeyStore.
+        self.public_keys = {}
 
         if power_ups:
             for power_up in power_ups:
@@ -35,24 +35,28 @@ class CryptoPower(object):
             power_up_instance = power_up()
         else:
             raise TypeError(
-                "power_up must be a subclass of CryptoPowerUp or an instance of a subclass of CryptoPowerUp.")
+                ("power_up must be a subclass of CryptoPowerUp or an instance "
+                 "of a subclass of CryptoPowerUp."))
         self._power_ups[power_up_class] = power_up_instance
 
         if power_up.confers_public_key:
+            # TODO: Make this an ID for later lookup on a KeyStore.
             self.public_keys[
-                power_up_class] = power_up_instance.public_key()  # TODO: Make this an ID for later lookup on a KeyStore.
+                power_up_class] = power_up_instance.public_key()
 
     def pubkey_sig_bytes(self):
         try:
+            # TODO: Turn this into an ID lookup on a KeyStore.
             return self._power_ups[
-                SigningKeypair].pub_key  # TODO: Turn this into an ID lookup on a KeyStore.
+                keypairs.SigningKeypair].pub_key
         except KeyError:
             raise NoSigningPower
 
     def pubkey_sig_tuple(self):
         try:
+            # TODO: Turn this into an ID lookup on a KeyStore.
             return API.ecdsa_bytes2pub(self._power_ups[
-                                           SigningKeypair].pub_key)  # TODO: Turn this into an ID lookup on a KeyStore.
+                                           keypairs.SigningKeypair].pub_key)
         except KeyError:
             raise NoSigningPower
 
@@ -64,7 +68,7 @@ class CryptoPower(object):
         :return: Signature of message
         """
         try:
-            sig_keypair = self._power_ups[SigningKeypair]
+            sig_keypair = self._power_ups[keypairs.SigningKeypair]
         except KeyError:
             raise NoSigningPower
         msg_digest = b"".join(API.keccak_digest(m) for m in messages)

--- a/nkms/keystore/keypairs.py
+++ b/nkms/keystore/keypairs.py
@@ -103,3 +103,14 @@ class SigningKeypair(Keypair):
 
     def _gen_pubkey(self):
         self.pubkey = API.ecdsa_priv2pub(self.privkey)
+
+    def sign(self, msghash: bytes) -> bytes:
+        """
+        Signs a hashed message and returns a signature.
+
+        :param msghash: The hashed message to sign
+
+        :return: Signature in bytes
+        """
+        v, r, s = API.ecdsa_sign(msghash, self.privkey)
+        return API.ecdsa_gen_sig(v, r, s)

--- a/nkms/keystore/keypairs.py
+++ b/nkms/keystore/keypairs.py
@@ -114,3 +114,15 @@ class SigningKeypair(Keypair):
         """
         v, r, s = API.ecdsa_sign(msghash, self.privkey)
         return API.ecdsa_gen_sig(v, r, s)
+
+    def verify(self, msghash: bytes, signature: bytes) -> bool:
+        """
+        Verifies that a signature came from this keypair.
+
+        :param msghash: Hashed message used in the signature
+        :param signature: Signature of the hashed message
+
+        :return: Boolean if the signature is valid
+        """
+        v, r, s = API.ecdsa_load_sig(signature)
+        return API.ecdsa_verify(v, r, s, msghash, self.pubkey)

--- a/nkms/keystore/keypairs.py
+++ b/nkms/keystore/keypairs.py
@@ -11,6 +11,9 @@ class Keypair(object):
 
     public_only = False
 
+    # TODO: Throw error if a key is called and it doesn't exist
+    # TODO: Maybe write a custome error ofr ^?
+
     def __init__(self, privkey: bytes = None, pubkey: bytes = None):
         if privkey and pubkey:
             self.privkey, self.pubkey = privkey, pubkey
@@ -20,9 +23,10 @@ class Keypair(object):
         elif privkey and not pubkey:
             # We have the privkey; use it to generate the pubkey.
             self.privkey = privkey
-            self.pubkey = API.privtopub(privkey)
+            self._gen_pubkey()
         elif pubkey and not privkey:
             # We have only the pubkey; this is a public-only pair.
+            self.pubkey = pubkey
             self.public_only = True
 
 
@@ -42,7 +46,10 @@ class EncryptingKeypair(Keypair):
         """
         self.privkey = API.ecies_gen_priv()
         if create_pubkey:
-            self.pubkey = API.ecies_priv2pub(self.privkey)
+            self._gen_pubkey()
+
+    def _gen_pubkey(self):
+        self.pubkey = API.ecies_priv2pub(self.privkey)
 
     def decrypt(self,
                 edata: Tuple[bytes, bytes],
@@ -75,18 +82,10 @@ class EncryptingKeypair(Keypair):
         return cipher.decrypt(edata)
 
 
-class SigningKeypair(object):
+class SigningKeypair(Keypair):
     """
     A SigningKeypair that uses ECDSA.
     """
-
-    def __init__(self, privkey: bytes = None, pubkey: bytes = None):
-        """
-        Initalizes a SigningKeypair object.
-        """
-        self.privkey = privkey
-        self.pubkey = pubkey
-        # TODO: Generate a KeyID as a keccak_digest of the pubkey,
 
     def gen_privkey(self, create_pubkey: bool = True):
         """
@@ -100,4 +99,7 @@ class SigningKeypair(object):
         """
         self.privkey = API.ecdsa_gen_priv()
         if create_pubkey:
-            self.pubkey = API.ecdsa_priv2pub(self.privkey)
+            self._gen_pubkey()
+
+    def _gen_pubkey(self):
+        self.pubkey = API.ecdsa_priv2pub(self.privkey)

--- a/tests/characters/test_crypto_characters_and_their_powers.py
+++ b/tests/characters/test_crypto_characters_and_their_powers.py
@@ -9,7 +9,7 @@ SIGNING
 """
 
 from nkms.crypto.constants import NO_DECRYPTION_PERFORMED
-from nkms.crypto.powers import CryptoPower, SigningKeypair, NoSigningPower, NoEncryptingPower, \
+from nkms.crypto.powers import CryptoPower, SigningPower, NoSigningPower, NoEncryptingPower, \
     EncryptingPower
 
 
@@ -40,7 +40,7 @@ def test_actor_with_signing_power_can_sign():
     """
     message = b"Llamas."
 
-    signer = Character(crypto_power_ups=[SigningKeypair])
+    signer = Character(crypto_power_ups=[SigningPower])
     seal_of_the_signer = signer.seal
 
     # We can use the signer's seal to sign a message...
@@ -93,7 +93,7 @@ def test_signing_only_power_cannot_encrypt():
     """
 
     # Here's somebody who can sign but not encrypt.
-    can_sign_but_not_encrypt = Character(crypto_power_ups=[SigningKeypair])
+    can_sign_but_not_encrypt = Character(crypto_power_ups=[SigningPower])
 
     # ..and here's Ursula, for whom our Character above wants to encrypt.
     ursula = Ursula()
@@ -113,7 +113,7 @@ def test_character_with_encrypting_power_can_encrypt():
     """
     Now, a Character *with* EncryptingKeyPair can encrypt.
     """
-    can_sign_and_encrypt = Character(crypto_power_ups=[SigningKeypair, EncryptingPower])
+    can_sign_and_encrypt = Character(crypto_power_ups=[SigningPower, EncryptingPower])
     ursula = Ursula()
     can_sign_and_encrypt.learn_about_actor(ursula)
 

--- a/tests/crypto/test_signing_power.py
+++ b/tests/crypto/test_signing_power.py
@@ -1,0 +1,28 @@
+import unittest
+from nkms.keystore import keypairs
+from nkms.crypto import api as API
+from nkms.crypto.powers import SigningPower
+
+
+class TestSigningPower(unittest.TestCase):
+    def setUp(self):
+        self.keypair = keypairs.SigningKeypair()
+        self.power = SigningPower(self.keypair)
+
+    def test_signing(self):
+        msghash = API.keccak_digest(b'hello world!')
+
+        sig = self.power.sign(msghash)
+        self.assertEqual(bytes, type(sig))
+        self.assertEqual(65, len(sig))
+
+        sig = API.ecdsa_load_sig(sig)
+        self.assertEqual(tuple, type(sig))
+        self.assertEqual(3, len(sig))
+        self.assertEqual(int, type(sig[0]))
+        self.assertEqual(int, type(sig[1]))
+        self.assertEqual(int, type(sig[2]))
+
+        v, r, s = sig
+        is_verify = API.ecdsa_verify(v, r, s, msghash, self.keypair.pubkey)
+        self.assertTrue(is_verify)

--- a/tests/crypto/test_signing_power.py
+++ b/tests/crypto/test_signing_power.py
@@ -16,13 +16,5 @@ class TestSigningPower(unittest.TestCase):
         self.assertEqual(bytes, type(sig))
         self.assertEqual(65, len(sig))
 
-        sig = API.ecdsa_load_sig(sig)
-        self.assertEqual(tuple, type(sig))
-        self.assertEqual(3, len(sig))
-        self.assertEqual(int, type(sig[0]))
-        self.assertEqual(int, type(sig[1]))
-        self.assertEqual(int, type(sig[2]))
-
-        v, r, s = sig
-        is_verify = API.ecdsa_verify(v, r, s, msghash, self.keypair.pubkey)
-        self.assertTrue(is_verify)
+        is_valid = self.keypair.verify(msghash, sig)
+        self.assertTrue(is_valid)

--- a/tests/keystore/test_keypairs.py
+++ b/tests/keystore/test_keypairs.py
@@ -1,4 +1,5 @@
 import unittest
+from nkms.crypto import api as API
 from nkms.keystore import keypairs
 
 
@@ -28,6 +29,23 @@ class TestKeypairs(unittest.TestCase):
         self.assertTrue(self.ecdsa_keypair.pubkey is not None)
         self.assertEqual(bytes, type(self.ecdsa_keypair.pubkey))
         self.assertEqual(64, len(self.ecdsa_keypair.pubkey))
+
+    def test_ecdsa_keypair_signing(self):
+        msghash = API.keccak_digest(b'hello world!')
+
+        sig = self.ecdsa_keypair.sign(msghash)
+        self.assertEqual(bytes, type(sig))
+        self.assertEqual(65, len(sig))
+
+    def test_ecdsa_keypair_verification(self):
+        msghash = API.keccak_digest(b'hello world!')
+
+        sig = self.ecdsa_keypair.sign(msghash)
+        self.assertEqual(bytes, type(sig))
+        self.assertEqual(65, len(sig))
+
+        is_valid = self.ecdsa_keypair.verify(msghash, sig)
+        self.assertTrue(is_valid)
 
     def test_keypair_object(self):
         # Test both keys

--- a/tests/keystore/test_keypairs.py
+++ b/tests/keystore/test_keypairs.py
@@ -28,3 +28,42 @@ class TestKeypairs(unittest.TestCase):
         self.assertTrue(self.ecdsa_keypair.pubkey is not None)
         self.assertEqual(bytes, type(self.ecdsa_keypair.pubkey))
         self.assertEqual(64, len(self.ecdsa_keypair.pubkey))
+
+    def test_keypair_object(self):
+        # Test both keys
+        keypair = keypairs.SigningKeypair(self.ecdsa_keypair.privkey,
+                                          self.ecdsa_keypair.pubkey)
+        self.assertTrue(keypair.public_only is False)
+
+        self.assertEqual(bytes, type(keypair.privkey))
+        self.assertEqual(32, len(keypair.privkey))
+
+        self.assertEqual(bytes, type(keypair.pubkey))
+        self.assertEqual(64, len(keypair.pubkey))
+
+        # Test no keys (key generation)
+        keypair = keypairs.SigningKeypair()
+        self.assertTrue(keypair.public_only is False)
+
+        self.assertEqual(bytes, type(keypair.privkey))
+        self.assertEqual(32, len(keypair.privkey))
+
+        self.assertEqual(bytes, type(keypair.pubkey))
+        self.assertEqual(64, len(keypair.pubkey))
+
+        # Test privkey only
+        keypair = keypairs.SigningKeypair(privkey=self.ecdsa_keypair.privkey)
+        self.assertTrue(keypair.public_only is False)
+
+        self.assertEqual(bytes, type(keypair.privkey))
+        self.assertEqual(32, len(keypair.privkey))
+
+        self.assertEqual(bytes, type(keypair.pubkey))
+        self.assertEqual(64, len(keypair.pubkey))
+
+        # Test pubkey only
+        keypair = keypairs.SigningKeypair(pubkey=self.ecdsa_keypair.pubkey)
+        self.assertTrue(keypair.public_only is True)
+
+        self.assertEqual(bytes, type(keypair.pubkey))
+        self.assertEqual(64, len(keypair.pubkey))


### PR DESCRIPTION
## What this does:
1. Implements `SigningPower` in `nkms.crypto.powers`.
    1. Adds tests in `tests.keystore.test_keypairs` and `tests.crypto.test_signing_power`.
    2. Fixes tests that use `SigningKeypair` and replaces it with `SigningPower`.
    3. Fixes character code that use `SigningKeypair` and uses `SigningPower`.

2. Implements a `sign` and `verify` method on `SigningKeypair`.
    1. `verify` verifies with the keypair's own public key.