### PR TITLE
Implement KeyNotFound Exception

### DIFF
--- a/nkms/keystore/keystore.py
+++ b/nkms/keystore/keystore.py
@@ -5,6 +5,13 @@ from nkms.keystore import constants
 from typing import Union
 
 
+class KeyNotFound(KeyError):
+    """
+    Exception class for KeyStore get_key calls for keys that don't exist.
+    """
+    pass
+
+
 class KeyStore(object):
     """
     A storage class of cryptographic keys.

--- a/nkms/keystore/keystore.py
+++ b/nkms/keystore/keystore.py
@@ -85,7 +85,7 @@ class KeyStore(object):
             key = txn.get(fingerprint)
 
         if not key:
-            return None
+            raise KeyNotFound("No key found with the provided fingerprint.")
 
         keypair_byte = key[0].to_bytes(1, 'big')
         key_type_byte = key[1].to_bytes(1, 'big')

--- a/nkms/keystore/keystore.py
+++ b/nkms/keystore/keystore.py
@@ -85,7 +85,8 @@ class KeyStore(object):
             key = txn.get(fingerprint)
 
         if not key:
-            raise KeyNotFound("No key found with the provided fingerprint.")
+            raise KeyNotFound(
+                    "No key with fingerprint {} found.".format(fingerprint))
 
         keypair_byte = key[0].to_bytes(1, 'big')
         key_type_byte = key[1].to_bytes(1, 'big')

--- a/tests/keystore/test_keystore.py
+++ b/tests/keystore/test_keystore.py
@@ -57,10 +57,10 @@ class TestKeyStore(unittest.TestCase):
 
         # Test del_key pubkey
         self.ks.del_key(fingerprint_pub)
-        key = self.ks.get_key(fingerprint_pub)
-        self.assertIsNone(key)
+        with self.assertRaises(keystore.KeyNotFound):
+            key = self.ks.get_key(fingerprint_pub)
 
         # Test del_key privkey
         self.ks.del_key(fingerprint_priv)
-        key = self.ks.get_key(fingerprint_priv)
-        self.assertIsNone(key)
+        with self.assertRaises(keystore.KeyNotFound):
+            key = self.ks.get_key(fingerprint_priv)


### PR DESCRIPTION
### What this does:
1. Adds a `KeyNotFound` Exception class.
    1. This gets raised in `KeyStore.get_key` when the fingerprint requested isn't found.

2. Implements `KeyNotFound` in the `tests.keystore.test_keystore` tests.