### PR TITLE
Add method for deserializing key in Keypair

### DIFF
--- a/nkms/keystore/keypairs.py
+++ b/nkms/keystore/keypairs.py
@@ -43,7 +43,7 @@ class Keypair(object):
         key_type_byte = key_data[1].to_bytes(1, 'big')
         key = key_data[2:]
 
-        if keypair_byte == constants.ENC_KEYPAIR_BYTES:
+        if keypair_byte == constants.ENC_KEYPAIR_BYTE:
             if key_type_byte == constants.PUB_KEY_BYTE:
                 return EncryptingKeypair(pubkey=key)
 

--- a/nkms/keystore/keypairs.py
+++ b/nkms/keystore/keypairs.py
@@ -30,6 +30,33 @@ class Keypair(object):
             self.pubkey = pubkey
             self.public_only = True
 
+    @staticmethod
+    def deserialize_key(key_data: bytes) -> 'Keypair':
+        """
+        Deserialize the key_data into a Keypair object.
+
+        :param key_data: Serialized key data from a keypair object
+
+        :return: Keypair object
+        """
+        keypair_byte = key_data[0].to_bytes(1, 'big')
+        key_type_byte = key_data[1].to_bytes(1, 'big')
+        key = key_data[2:]
+
+        if keypair_byte == constants.ENC_KEYPAIR_BYTES:
+            if key_type_byte == constants.PUB_KEY_BYTE:
+                return EncryptingKeypair(pubkey=key)
+
+            elif key_type_byte == constants.PRIV_KEY_BYTE:
+                return EncryptingKeypair(privkey=key)
+
+        elif keypair_byte == constants.SIG_KEYPAIR_BYTE:
+            if key_type_byte == constants.PUB_KEY_BYTE:
+                return SigningKeypair(pubkey=key)
+
+            elif key_type_byte == constants.PRIV_KEY_BYTE:
+                return SigningKeypair(privkey=key)
+
 
 class EncryptingKeypair(Keypair):
     """

--- a/nkms/keystore/keystore.py
+++ b/nkms/keystore/keystore.py
@@ -79,24 +79,7 @@ class KeyStore(object):
         if not key:
             raise KeyNotFound(
                     "No key with fingerprint {} found.".format(fingerprint))
-
-        keypair_byte = key.key_data[0].to_bytes(1, 'big')
-        key_type_byte = key.key_data[1].to_bytes(1, 'big')
-        key = key.key_data[2:]
-
-        if keypair_byte == constants.ENC_KEYPAIR_BYTE:
-            if key_type_byte == constants.PUB_KEY_BYTE:
-                return keypairs.EncryptingKeypair(pubkey=key)
-
-            elif key_type_byte == constants.PRIV_KEY_BYTE:
-                return keypairs.EncryptingKeypair(privkey=key)
-
-        elif keypair_byte == constants.SIG_KEYPAIR_BYTE:
-            if key_type_byte == constants.PUB_KEY_BYTE:
-                return keypairs.SigningKeypair(pubkey=key)
-
-            elif key_type_byte == constants.PRIV_KEY_BYTE:
-                return keypairs.SigningKeypair(privkey=key)
+        return keypairs.Keypair.deserialize_key(key.key_data)
 
     def add_key(self,
                 keypair: Union[keypairs.EncryptingKeypair,

--- a/tests/keystore/test_keypairs.py
+++ b/tests/keystore/test_keypairs.py
@@ -37,6 +37,14 @@ class TestKeypairs(unittest.TestCase):
         self.assertEqual(bytes, type(sig))
         self.assertEqual(65, len(sig))
 
+    def test_key_serialization(self):
+        ser_key = self.ecdsa_keypair.serialize_privkey()
+        self.assertEqual(34, len(ser_key))
+
+        deser_key = keypairs.Keypair.deserialize_key(ser_key)
+        self.assertEqual(keypairs.SigningKeypair, type(deser_key))
+        self.assertEqual(self.ecdsa_keypair.privkey, deser_key.privkey)
+
     def test_ecdsa_keypair_verification(self):
         msghash = API.keccak_digest(b'hello world!')
 


### PR DESCRIPTION
### What this does:
1. Adds a method for deserializing a serialized key in `Keypair`.
2. Adds test for serializing and deserializing a key.
3. Calls `Keypair.deserialize_key` in `Keystore.get_key`.