### PR TITLE
Metabytes for key generation, PublicKey class, and safety for public key de/serialization.

### DIFF
--- a/nkms/characters.py
+++ b/nkms/characters.py
@@ -8,7 +8,7 @@ from nkms.crypto import api as API
 from nkms.crypto.api import secure_random, keccak_digest
 from nkms.crypto.constants import NOT_SIGNED, NO_DECRYPTION_PERFORMED
 from nkms.crypto.powers import CryptoPower, SigningPower, EncryptingPower
-from nkms.keystore.keypairs import Keypair
+from nkms.keystore.keypairs import Keypair, PublicKey
 from nkms.network import blockchain_client
 from nkms.network.blockchain_client import list_all_ursulas
 from nkms.network.protocols import dht_value_splitter
@@ -175,7 +175,7 @@ class Alice(Character):
         :return: Tuple(kfrags, eph_key_data)
         """
         kfrags, eph_key_data = API.ecies_ephemeral_split_rekey(
-            alice_privkey, bytes(bob.seal), m, n)
+            alice_privkey, bytes(bob.seal.without_metabytes()), m, n)
         return (kfrags, eph_key_data)
 
     def publish_treasure_map(self, policy_group):
@@ -330,6 +330,9 @@ class Seal(object):
 
     def __len__(self):
         return len(bytes(self))
+
+    def without_metabytes(self):
+        return self.character._crypto_power.pubkey_sig_bytes().without_metabytes()
 
 
 class StrangerSeal(Seal):

--- a/nkms/crypto/api.py
+++ b/nkms/crypto/api.py
@@ -4,8 +4,9 @@ from typing import Tuple, Union, List
 import sha3
 from nacl.secret import SecretBox
 from py_ecc.secp256k1 import N, privtopub, ecdsa_raw_recover, ecdsa_raw_sign
-from nkms.crypto import _internal
 
+from nkms.crypto import _internal
+from nkms.keystore.constants import SIG_KEYPAIR_BYTE, PUB_KEY_BYTE
 from npre import elliptic_curve
 from npre import umbral
 
@@ -14,7 +15,7 @@ SYSTEM_RAND = SystemRandom()
 
 
 def secure_random(
-    num_bytes: int
+        num_bytes: int
 ) -> bytes:
     """
     Returns an amount `num_bytes` of data from the OS's random device.
@@ -27,13 +28,13 @@ def secure_random(
     :return: bytes
     """
     # TODO: Should we just use os.urandom or avoid the import w/ this?
-    return SYSTEM_RAND.getrandbits(num_bytes*8).to_bytes(num_bytes,
-                                                         byteorder='big')
+    return SYSTEM_RAND.getrandbits(num_bytes * 8).to_bytes(num_bytes,
+                                                           byteorder='big')
 
 
 def secure_random_range(
-    min: int,
-    max: int
+        min: int,
+        max: int
 ) -> int:
     """
     Returns a number from a secure random source betwee the range of
@@ -48,7 +49,7 @@ def secure_random_range(
 
 
 def keccak_digest(
-    *messages: bytes
+        *messages: bytes
 ) -> bytes:
     """
     Accepts an iterable containing bytes and digests it returning a
@@ -66,7 +67,7 @@ def keccak_digest(
 
 
 def ecdsa_pub2bytes(
-    pubkey: Tuple[int]
+        pubkey: Tuple[int]
 ) -> bytes:
     """
     Takes an ECDSA public key and converts to bytes.
@@ -77,11 +78,11 @@ def ecdsa_pub2bytes(
     """
     x = pubkey[0].to_bytes(32, byteorder='big')
     y = pubkey[1].to_bytes(32, byteorder='big')
-    return x+y
+    return x + y
 
 
 def ecdsa_bytes2pub(
-    pubkey: bytes
+        pubkey: bytes
 ) -> Tuple[int]:
     """
     Takes a byte encoded ECDSA public key and converts to a Tuple of x, and y
@@ -102,12 +103,12 @@ def ecdsa_gen_priv() -> bytes:
     :return: Byte encoded ECDSA privkey
     """
     privkey = secure_random_range(1, N)
-    return privkey.to_bytes(32, byteorder='big')
+    return privkey.to_bytes(32, byteorder='big')  # TODO: Add metabytes.
 
 
 def ecdsa_priv2pub(
-    privkey: bytes,
-    to_bytes: bool = True
+        privkey: bytes,
+        to_bytes: bool = True
 ) -> Union[bytes, Tuple[int]]:
     """
     Returns the public component of an ECDSA private key.
@@ -119,14 +120,14 @@ def ecdsa_priv2pub(
     """
     pubkey = privtopub(privkey)
     if to_bytes:
-        return ecdsa_pub2bytes(pubkey)
+        return SIG_KEYPAIR_BYTE + PUB_KEY_BYTE + ecdsa_pub2bytes(pubkey)
     return pubkey
 
 
 def ecdsa_gen_sig(
-    v: int,
-    r: int,
-    s: int
+        v: int,
+        r: int,
+        s: int
 ) -> bytes:
     """
     Generates an ECDSA signature, in bytes.
@@ -140,11 +141,11 @@ def ecdsa_gen_sig(
     v = v.to_bytes(1, byteorder='big')
     r = r.to_bytes(32, byteorder='big')
     s = s.to_bytes(32, byteorder='big')
-    return v+r+s
+    return v + r + s
 
 
 def ecdsa_load_sig(
-    signature: bytes
+        signature: bytes
 ) -> Tuple[int]:
     """
     Loads an ECDSA signature, from a bytestring, to a tuple.
@@ -160,8 +161,8 @@ def ecdsa_load_sig(
 
 
 def ecdsa_sign(
-    msghash: bytes,
-    privkey: bytes
+        msghash: bytes,
+        privkey: bytes
 ) -> Tuple[int]:
     """
     Accepts a hashed message and signs it with the private key given.
@@ -176,11 +177,11 @@ def ecdsa_sign(
 
 
 def ecdsa_verify(
-    v: int,
-    r: int,
-    s: int,
-    msghash: bytes,
-    pubkey: Union[bytes, Tuple[int]]
+        v: int,
+        r: int,
+        s: int,
+        msghash: bytes,
+        pubkey: Union[bytes, Tuple[int]]
 ) -> bool:
     """
     Takes a v, r, s, a pubkey, and a hash of a message to verify via ECDSA.

--- a/nkms/crypto/constants.py
+++ b/nkms/crypto/constants.py
@@ -1,5 +1,4 @@
 # TODO: Turn these into classes?
-PUBKEY_SIG_LENGTH = 64
 HASH_DIGEST_LENGTH = 32
 
 NOT_SIGNED = 445

--- a/nkms/crypto/signature.py
+++ b/nkms/crypto/signature.py
@@ -1,4 +1,5 @@
 from nkms.crypto import api as API
+from nkms.keystore.keypairs import PublicKey
 
 
 class Signature(bytes):
@@ -34,7 +35,7 @@ class Signature(bytes):
     def __repr__(self):
         return "{} v{}: {} - {}".format(__class__.__name__, self._v, self._r, self._s)
 
-    def verify(self, message: bytes, pubkey: bytes) -> bool:
+    def verify(self, message: bytes, pubkey: PublicKey) -> bool:
         """
         Verifies that a message's signature was valid.
 
@@ -44,7 +45,7 @@ class Signature(bytes):
         :return: True if valid, False if invalid
         """
         msg_digest = API.keccak_digest(message)
-        return API.ecdsa_verify(self._v, self._r, self._s, msg_digest, pubkey)
+        return API.ecdsa_verify(self._v, self._r, self._s, msg_digest, pubkey.without_metabytes())
 
     def __bytes__(self):
         """

--- a/nkms/keystore/keypairs.py
+++ b/nkms/keystore/keypairs.py
@@ -56,6 +56,8 @@ class Keypair(object):
 
             elif key_type_byte == constants.PRIV_KEY_BYTE:
                 return SigningKeypair(privkey=key)
+        else:
+            raise ValueError("Unable to determine which type of keypair this is - keypair_byte was {}".format(keypair_byte))
 
 
 class EncryptingKeypair(Keypair):

--- a/nkms/keystore/keypairs.py
+++ b/nkms/keystore/keypairs.py
@@ -154,7 +154,7 @@ class SigningKeypair(Keypair):
             self._gen_pubkey()
 
     def _gen_pubkey(self):
-        self.pubkey = API.ecdsa_priv2pub(self.privkey)
+        self.pubkey = PublicKey(API.ecdsa_priv2pub(self.privkey))
 
     def sign(self, msghash: bytes) -> bytes:
         """
@@ -177,7 +177,7 @@ class SigningKeypair(Keypair):
         :return: Boolean if the signature is valid
         """
         v, r, s = API.ecdsa_load_sig(signature)
-        return API.ecdsa_verify(v, r, s, msghash, self.pubkey)
+        return API.ecdsa_verify(v, r, s, msghash, self.pubkey.without_metabytes())
 
     def serialize_pubkey(self) -> bytes:
         """
@@ -200,3 +200,11 @@ class SigningKeypair(Keypair):
                           constants.PRIV_KEY_BYTE +
                           self.privkey)
         return serialized_key
+
+
+class PublicKey(bytes):
+    _EXPECTED_LENGTH = 66
+    _METABYTES_LENGTH = 2
+
+    def without_metabytes(self):
+        return self[self._METABYTES_LENGTH::]

--- a/nkms/network/protocols.py
+++ b/nkms/network/protocols.py
@@ -4,14 +4,15 @@ from kademlia.node import Node
 from kademlia.protocol import KademliaProtocol
 from kademlia.utils import digest
 from nkms.crypto.api import keccak_digest
-from nkms.crypto.constants import PUBKEY_SIG_LENGTH, HASH_DIGEST_LENGTH
+from nkms.crypto.constants import HASH_DIGEST_LENGTH
 from nkms.crypto.signature import Signature
 from nkms.crypto.utils import BytestringSplitter
+from nkms.keystore.keypairs import PublicKey
 from nkms.network.constants import NODE_HAS_NO_STORAGE
 from nkms.network.node import NuCypherNode
 from nkms.network.routing import NuCypherRoutingTable
 
-dht_value_splitter = BytestringSplitter(Signature, (bytes, PUBKEY_SIG_LENGTH), (bytes, HASH_DIGEST_LENGTH))
+dht_value_splitter = BytestringSplitter(Signature, PublicKey, (bytes, HASH_DIGEST_LENGTH))
 
 
 class NuCypherHashProtocol(KademliaProtocol):

--- a/nkms/network/protocols.py
+++ b/nkms/network/protocols.py
@@ -47,13 +47,7 @@ class NuCypherHashProtocol(KademliaProtocol):
     def determine_legality_of_dht_key(self, signature, sender_pubkey_sig, message, hrac, dht_key, dht_value):
         proper_key = digest(keccak_digest(bytes(sender_pubkey_sig) + bytes(hrac)))
 
-        # TODO: This try block is not the right approach - a Ciphertext class can resolve this instead.
-        try:
-            # Ursula uaddr scenario
-            verified = signature.verify(hrac, sender_pubkey_sig)
-        except Exception as e:
-            # trmap scenario
-            verified = signature.verify(msgpack.dumps(message), sender_pubkey_sig)
+        verified = signature.verify(hrac, sender_pubkey_sig)
 
         if not verified or not proper_key == dht_key:
             self.log.warning("Got request to store illegal k/v: {} / {}".format(dht_key, dht_value))

--- a/tests/characters/test_crypto_characters_and_their_powers.py
+++ b/tests/characters/test_crypto_characters_and_their_powers.py
@@ -47,7 +47,7 @@ def test_actor_with_signing_power_can_sign():
 
     # ...or to get the signer's public key for verification purposes.
     sig = api.ecdsa_load_sig(bytes(signature))
-    verification = api.ecdsa_verify(*sig, api.keccak_digest(message), seal_of_the_signer)
+    verification = api.ecdsa_verify(*sig, api.keccak_digest(message), seal_of_the_signer.without_metabytes())
 
     assert verification is True
 

--- a/tests/crypto/test_api.py
+++ b/tests/crypto/test_api.py
@@ -1,10 +1,13 @@
-import unittest
 import random
+import unittest
+
 import sha3
 from nacl.utils import EncryptedMessage
-from npre import umbral
-from npre import elliptic_curve as ec
+
 from nkms.crypto import api
+from nkms.keystore.keypairs import PublicKey
+from npre import elliptic_curve as ec
+from npre import umbral
 
 
 class TestCrypto(unittest.TestCase):
@@ -85,7 +88,7 @@ class TestCrypto(unittest.TestCase):
         pubkey_bytes = api.ecdsa_priv2pub(privkey)
         self.assertEqual(bytes, type(pubkey_bytes))
 
-        pubkey = api.ecdsa_bytes2pub(pubkey_bytes)
+        pubkey = api.ecdsa_bytes2pub(pubkey_bytes[PublicKey._METABYTES_LENGTH::])
         self.assertEqual(tuple, type(pubkey))
         self.assertEqual(2, len(pubkey))
         self.assertEqual(int, type(pubkey[0]))
@@ -106,7 +109,7 @@ class TestCrypto(unittest.TestCase):
         # Test Serialization
         pubkey = api.ecdsa_priv2pub(privkey)
         self.assertEqual(bytes, type(pubkey))
-        self.assertEqual(64, len(pubkey))
+        self.assertEqual(PublicKey._EXPECTED_LENGTH, len(pubkey))
 
         # Test no serialization
         pubkey = api.ecdsa_priv2pub(privkey, to_bytes=False)
@@ -271,7 +274,7 @@ class TestCrypto(unittest.TestCase):
 
         # Check no serialization
         rekey = api.ecies_rekey(self.privkey_a_bytes, self.privkey_b_bytes,
-                                   to_bytes=False)
+                                to_bytes=False)
         self.assertEqual(umbral.RekeyFrag, type(rekey))
         self.assertEqual(ec.ec_element, type(rekey.key))
 
@@ -283,7 +286,7 @@ class TestCrypto(unittest.TestCase):
 
         # Check with conversion
         frags = api.ecies_split_rekey(self.privkey_a_bytes,
-                                         self.privkey_b_bytes, 3, 4)
+                                      self.privkey_b_bytes, 3, 4)
         self.assertEqual(list, type(frags))
         self.assertEqual(4, len(frags))
 
@@ -338,14 +341,10 @@ class TestCrypto(unittest.TestCase):
         self.assertEqual(32, len(plain_key))
 
         rk_eb = api.ecies_rekey(eph_priv, self.privkey_b,
-                                   to_bytes=False)
+                                to_bytes=False)
         self.assertEqual(umbral.RekeyFrag, type(rk_eb))
         self.assertEqual(ec.ec_element, type(rk_eb.key))
 
         reenc_key = api.ecies_reencrypt(rk_eb, enc_key)
         dec_key = api.ecies_decapsulate(self.privkey_b, reenc_key)
         self.assertEqual(plain_key, dec_key)
-
-    def test_alpha_is_resolved(self):
-        with self.assertRaises(ImportError):
-            from nkms.crypto import _alpha

--- a/tests/keystore/test_keypairs.py
+++ b/tests/keystore/test_keypairs.py
@@ -1,6 +1,7 @@
 import unittest
 from nkms.crypto import api as API
 from nkms.keystore import keypairs
+from nkms.keystore.keypairs import PublicKey
 
 
 class TestKeypairs(unittest.TestCase):
@@ -27,8 +28,7 @@ class TestKeypairs(unittest.TestCase):
         self.assertEqual(32, len(self.ecdsa_keypair.privkey))
 
         self.assertTrue(self.ecdsa_keypair.pubkey is not None)
-        self.assertEqual(bytes, type(self.ecdsa_keypair.pubkey))
-        self.assertEqual(64, len(self.ecdsa_keypair.pubkey))
+        self.assertEqual(PublicKey._EXPECTED_LENGTH, len(self.ecdsa_keypair.pubkey))
 
     def test_ecdsa_keypair_signing(self):
         msghash = API.keccak_digest(b'hello world!')
@@ -64,8 +64,7 @@ class TestKeypairs(unittest.TestCase):
         self.assertEqual(bytes, type(keypair.privkey))
         self.assertEqual(32, len(keypair.privkey))
 
-        self.assertEqual(bytes, type(keypair.pubkey))
-        self.assertEqual(64, len(keypair.pubkey))
+        self.assertEqual(PublicKey._EXPECTED_LENGTH, len(keypair.pubkey))
 
         # Test no keys (key generation)
         keypair = keypairs.SigningKeypair()
@@ -74,8 +73,7 @@ class TestKeypairs(unittest.TestCase):
         self.assertEqual(bytes, type(keypair.privkey))
         self.assertEqual(32, len(keypair.privkey))
 
-        self.assertEqual(bytes, type(keypair.pubkey))
-        self.assertEqual(64, len(keypair.pubkey))
+        self.assertEqual(PublicKey._EXPECTED_LENGTH, len(keypair.pubkey))
 
         # Test privkey only
         keypair = keypairs.SigningKeypair(privkey=self.ecdsa_keypair.privkey)
@@ -83,13 +81,10 @@ class TestKeypairs(unittest.TestCase):
 
         self.assertEqual(bytes, type(keypair.privkey))
         self.assertEqual(32, len(keypair.privkey))
-
-        self.assertEqual(bytes, type(keypair.pubkey))
-        self.assertEqual(64, len(keypair.pubkey))
+        self.assertEqual(PublicKey._EXPECTED_LENGTH, len(keypair.pubkey))
 
         # Test pubkey only
         keypair = keypairs.SigningKeypair(pubkey=self.ecdsa_keypair.pubkey)
         self.assertTrue(keypair.public_only is True)
 
-        self.assertEqual(bytes, type(keypair.pubkey))
-        self.assertEqual(64, len(keypair.pubkey))
+        self.assertEqual(PublicKey._EXPECTED_LENGTH, len(keypair.pubkey))

--- a/tests/keystore/test_keystore.py
+++ b/tests/keystore/test_keystore.py
@@ -24,7 +24,6 @@ class TestKeyStore(unittest.TestCase):
         keypair = self.ks.generate_signing_keypair()
         self.assertEqual(keypairs.SigningKeypair, type(keypair))
         self.assertEqual(bytes, type(keypair.privkey))
-        self.assertEqual(bytes, type(keypair.pubkey))
 
     def test_key_sqlite_keystore(self):
         keypair = self.ks.generate_encrypting_keypair()

--- a/tests/network/test_network_actors.py
+++ b/tests/network/test_network_actors.py
@@ -6,9 +6,6 @@ import pytest
 
 from kademlia.utils import digest
 from nkms.characters import Ursula, Alice, Character, Bob, congregate
-from nkms.crypto.constants import PUBKEY_SIG_LENGTH, HASH_DIGEST_LENGTH
-from nkms.crypto.signature import Signature
-from nkms.crypto.utils import BytestringSplitter
 from nkms.network.blockchain_client import list_all_ursulas
 from nkms.network.protocols import dht_value_splitter
 from nkms.policy.constants import NON_PAYMENT
@@ -113,7 +110,8 @@ def test_alice_finds_ursula():
     getter = ALICE.server.get(all_ursulas[ursula_index])
     loop = asyncio.get_event_loop()
     value = loop.run_until_complete(getter)
-    _signature, _ursula_pubkey_sig, _hrac, interface_info = dht_value_splitter(value.lstrip(b"uaddr-"), return_remainder=True)
+    _signature, _ursula_pubkey_sig, _hrac, interface_info = dht_value_splitter(value.lstrip(b"uaddr-"),
+                                                                               return_remainder=True)
     port = msgpack.loads(interface_info)[0]
     assert port == URSULA_PORT + ursula_index
 
@@ -174,7 +172,7 @@ def test_treasure_map_with_bad_id_does_not_propagate():
     treasure_map = policy_group.treasure_map
 
     encrypted_treasure_map, signature = ALICE.encrypt_for(BOB, treasure_map.packed_payload())
-    packed_encrypted_treasure_map = msgpack.dumps(encrypted_treasure_map)  #TODO: #114?  Do we even need to pack here?
+    packed_encrypted_treasure_map = msgpack.dumps(encrypted_treasure_map)  # TODO: #114?  Do we even need to pack here?
 
     setter = ALICE.server.set(illegal_policygroup_id, packed_encrypted_treasure_map)
     _set_event = EVENT_LOOP.run_until_complete(setter)
@@ -226,6 +224,7 @@ def test_treaure_map_is_legit():
         getter = ALICE.server.get(ursula_interface_id)
         loop = asyncio.get_event_loop()
         value = loop.run_until_complete(getter)
-        signature, ursula_pubkey_sig, hrac, interface_info = dht_value_splitter(value.lstrip(b"uaddr-"), return_remainder=True)
+        signature, ursula_pubkey_sig, hrac, interface_info = dht_value_splitter(value.lstrip(b"uaddr-"),
+                                                                                return_remainder=True)
         port = msgpack.loads(interface_info)[0]
         assert port in URSULA_PORTS


### PR DESCRIPTION
Public Keys are now generated with metabytes.

**This PR does not include metabytes for Private Keys - only public.**

A `PublicKey` class includes metadata for total length and metabyte length as well as a facility for stripping metabytes. 