### PR TITLE
[WIP] Implement `Policy` in Keystore models

### DIFF
--- a/nkms/characters.py
+++ b/nkms/characters.py
@@ -482,7 +482,7 @@ class Ursula(Character):
         contract = Contract(alice=alice, hrac=hrac, kfrag=kfrag, **contract_details)
 
         try:
-            self.keystore.add_kfrag(hrac, contract.kfrag, alices_signature)
+            self.keystore.add_kfrag(hrac, policy)
         except IntegrityError:
             raise
             # Do something appropriately RESTful (ie, 4xx).

--- a/nkms/keystore/db/models.py
+++ b/nkms/keystore/db/models.py
@@ -1,7 +1,8 @@
 import sha3
 
 from nkms.keystore.db import Base
-from sqlalchemy import Column, Integer, LargeBinary, relationship, ForeignKey
+from sqlalchemy import Column, Integer, LargeBinary, ForeignKey
+from sqlalchemy.orm import relationship
 
 
 class Key(Base):
@@ -10,7 +11,8 @@ class Key(Base):
     id = Column(Integer, primary_key=True)
     fingerprint = Column(LargeBinary, unique=True)
     key_data = Column(LargeBinary, unique=True)
-    policy = relationship("Policy", uselist=False, back_populates="keys")
+
+    policy = relationship("Policy", uselist=False, back_populates="policies")
 
     def __init__(self, key_data):
         self.key_data = key_data
@@ -31,12 +33,11 @@ class KeyFrag(Base):
     __tablename__ = 'keyfrags'
 
     id = Column(Integer, primary_key=True)
-    hrac = Column(LargeBinary, unique=True)
     key_frag = Column(LargeBinary, unique=True)
+
     policy = relationship("Policy", uselist=False, back_populates="policies")
 
-    def __init__(self, hrac, key_frag):
-        self.hrac = hrac
+    def __init__(self, key_frag):
         self.key_frag = key_frag
 
 
@@ -51,3 +52,9 @@ class Policy(Base):
 
     keyfrag = relationship("KeyFrag", back_populates="policies")
     alice_pubkey = relationship("KeyFrag", back_populates="policies")
+
+    def __init__(self, hrac, alice_sig, keyfrag, alice_pubkey):
+        self.hrac = hrac
+        self.alice_sig = alice_sig
+        self.keyfrag_id = keyfrag.id
+        self.alice_pubkey_id = alice_pubkey.id

--- a/nkms/keystore/db/models.py
+++ b/nkms/keystore/db/models.py
@@ -1,7 +1,7 @@
 import sha3
 
 from nkms.keystore.db import Base
-from sqlalchemy import Column, Integer, LargeBinary
+from sqlalchemy import Column, Integer, LargeBinary, relationship, ForeignKey
 
 
 class Key(Base):
@@ -10,6 +10,7 @@ class Key(Base):
     id = Column(Integer, primary_key=True)
     fingerprint = Column(LargeBinary, unique=True)
     key_data = Column(LargeBinary, unique=True)
+    policy = relationship("Policy", uselist=False, back_populates="keys")
 
     def __init__(self, key_data):
         self.key_data = key_data
@@ -32,7 +33,21 @@ class KeyFrag(Base):
     id = Column(Integer, primary_key=True)
     hrac = Column(LargeBinary, unique=True)
     key_frag = Column(LargeBinary, unique=True)
+    policy = relationship("Policy", uselist=False, back_populates="policies")
 
     def __init__(self, hrac, key_frag):
         self.hrac = hrac
         self.key_frag = key_frag
+
+
+class Policy(Base):
+    __tablename__ = 'policies'
+
+    id = Column(Integer, primary_key=True)
+    hrac = Column(LargeBinary, unique=True)
+    alice_sig = Column(LargeBinary)
+    keyfrag_id = Column(Integer, ForeignKey('keyfrags.id'))
+    alice_pubkey_id = Column(Integer, ForeignKey('keys.id'))
+
+    keyfrag = relationship("KeyFrag", back_populates="policies")
+    alice_pubkey = relationship("KeyFrag", back_populates="policies")


### PR DESCRIPTION
### What this does:
1. Adds a `Policy` object to the Keystore models.
2. Implements ForeignKeys and relationships for each of the other Keystore models to integrate with the `Policy`.
3. Breaks a lot of thing using the Keystore.

### TODO:
1. Implement Policy stuff for the rest of the KMS.
2. Handle all the breakage for moving some of the other model data to the `Policy` model.
3. Handle weird SQLAlchemy issues...