### PR TITLE
Separating Delegation from Encapsulation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,5 @@ install:
 - pip install pipenv --upgrade
 - pipenv install --dev --three
 script:
-- pipenv run "pytest --cov=nkms -v tests"
+- pipenv run -- pytest --cov=nkms -v tests
 - codecov
-notifications:
-  slack:
-    secure: ZGr5vpk+YoQiOqp0ABXUZZyRNL8egBbJGvpTvmmde3pV7wNjjrNvuVHJ6CHHiOiwULojg/+iDYaO//saMHicXI+dFZs9FuyiLR3YbjPF3UCdCFG8fI3EUaFHU+OTY+kSYx9ZvrXFqzGixNpwPCy7kHR22E58yXLTLSPZpNdq7bZsAcHt2DOTnNUO96Rr+1UGekEB+zDqGpJvYR6zujkNe+dO3ZJTp9ldTEKyl93dVLqKuEwsMdd7HMWLucL8aQKdJ8PMz9zxfNpLNHiM4aqgiJz0ZMgjQXOfoDeaF47G9RhGbuX23FodP1u4Lje15dIZ/Lk9w/zMrpu8lY+YDond0ir4atDKYRi9TRzsTlqtJYgpPi5toKd5LBiEk5pkqyQn5M7YS7OcSLVcP2p5Fb8XIlJeACxe0N/lwdgbKRwEypqBbZ+fYQJPMkmi3zCxpfojjCXOs+zuNo/EQ2K/qaQA8H/zBNlhiuFKX3yWY+aVGvvYLqYzjGOy92jrU7OSvnKp+PeTGGWA/XDfNbGmt5aFhE3arzw6Y/W6coDG7Nl+eMlSb7ZZCXvnmV/tip+RrxmWY5q75Anc0DQ4Aui+cNeW1Ew8wIPuRwgPsOcgxE2PYSayvsSizoz7r6nGKnWl6SwNj70YFyXs17xQ3/B9RspyUC6EpXa0Ozg/KqRvJuQ5PY8=

--- a/nkms/characters.py
+++ b/nkms/characters.py
@@ -19,7 +19,7 @@ from nkms.config.configs import KMSConfig
 from nkms.crypto.api import secure_random, keccak_digest
 from nkms.crypto.constants import PUBLIC_KEY_LENGTH
 from nkms.crypto.kits import UmbralMessageKit
-from nkms.crypto.powers import CryptoPower, SigningPower, EncryptingPower
+from nkms.crypto.powers import CryptoPower, SigningPower, EncryptingPower, DelegatingPower
 from nkms.crypto.signature import Signature
 from nkms.crypto.splitters import signature_splitter
 from nkms.network import blockchain_client
@@ -303,7 +303,7 @@ class FakePolicyAgent:  # TODO: #192
 
 class Alice(Character, PolicyAuthor):
     _server_class = NuCypherSeedOnlyDHTServer
-    _default_crypto_powerups = [SigningPower, EncryptingPower]
+    _default_crypto_powerups = [SigningPower, EncryptingPower, DelegatingPower]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -320,7 +320,7 @@ class Alice(Character, PolicyAuthor):
         :param n: Total number of kfrags to generate
         """
         bob_pubkey_enc = bob.public_key(EncryptingPower)
-        return self._crypto_power.power_ups(EncryptingPower).generate_kfrags(bob_pubkey_enc, m, n)
+        return self._crypto_power.power_ups(DelegatingPower).generate_kfrags(bob_pubkey_enc, m, n)
 
     def create_policy(self, bob: "Bob", uri: bytes, m: int, n: int):
         """

--- a/nkms/characters.py
+++ b/nkms/characters.py
@@ -171,26 +171,13 @@ class Character(object):
         :return: A tuple, (ciphertext, signature).  If sign==False,
             then signature will be NOT_SIGNED.
         """
-        recipient_pubkey_enc = recipient.public_key(EncryptingPower)
-        if sign:
-            if sign_plaintext:
-                # Sign first, encrypt second.
-                sig_header = constants.SIGNATURE_TO_FOLLOW
-                signature = self.stamp(plaintext)
-                ciphertext, capsule = pre.encrypt(recipient_pubkey_enc, sig_header + signature + plaintext)
-            else:
-                # Encrypt first, sign second.
-                sig_header = constants.SIGNATURE_IS_ON_CIPHERTEXT
-                ciphertext, capsule = pre.encrypt(recipient_pubkey_enc, sig_header + plaintext)
-                signature = self.stamp(ciphertext)
-            alice_pubkey = self.public_key(SigningPower)
-        else:
-            # Don't sign.
-            signature = sig_header = constants.NOT_SIGNED
-            alice_pubkey = None
-            ciphertext, capsule = pre.encrypt(recipient_pubkey_enc, sig_header + plaintext)
-        message_kit = UmbralMessageKit(ciphertext=ciphertext, capsule=capsule, alice_pubkey=alice_pubkey)
+        signer = self.stamp if sign else constants.DO_NOT_SIGN.bool_value(False)
 
+        message_kit, signature = encrypt_and_sign(recipient_pubkey_enc=recipient.public_key(EncryptingPower),
+                                                  plaintext=plaintext,
+                                                  signer=signer,
+                                                  sign_plaintext=sign_plaintext
+                                                  )
         return message_kit, signature
 
     def verify_from(self,

--- a/nkms/characters.py
+++ b/nkms/characters.py
@@ -198,13 +198,13 @@ class Character(object):
         :return: Whether or not the signature is valid, the decrypted plaintext
             or NO_DECRYPTION_PERFORMED
         """
+        sender_pubkey_sig = actor_whom_sender_claims_to_be.stamp.as_umbral_pubkey()
         with suppress(AttributeError):
-            if message_kit.alice_pubkey:
-                if not message_kit.alice_pubkey == actor_whom_sender_claims_to_be.public_key(SigningPower):
+            if message_kit.sender_pubkey_sig:
+                if not message_kit.sender_pubkey_sig == sender_pubkey_sig:
                     raise ValueError(
                         "This MessageKit doesn't appear to have come from {}".format(actor_whom_sender_claims_to_be))
 
-        alice_pubkey = actor_whom_sender_claims_to_be.public_key(SigningPower)
         signature_from_kit = None
 
         if decrypt:
@@ -234,7 +234,7 @@ class Character(object):
         signature_to_use = signature or signature_from_kit
 
         if signature_to_use:
-            is_valid = signature_to_use.verify(message, alice_pubkey)
+            is_valid = signature_to_use.verify(message, sender_pubkey_sig)
         else:
             # Meh, we didn't even get a signature.  Not much we can do.
             is_valid = False

--- a/nkms/characters.py
+++ b/nkms/characters.py
@@ -546,7 +546,7 @@ class Ursula(Character, ProxyRESTServer):
             raise RuntimeError("Got a bad response: {}".format(response))
 
         key_splitter = RepeatingBytestringSplitter(
-            (UmbralPublicKey, PUBLIC_KEY_LENGTH, {"as_b64": False}))
+            (UmbralPublicKey, PUBLIC_KEY_LENGTH))
         signing_key, encrypting_key = key_splitter(response.content)
 
         stranger_ursula_from_public_keys = cls.from_public_keys(

--- a/nkms/characters.py
+++ b/nkms/characters.py
@@ -504,6 +504,10 @@ class Bob(Character):
         return self._ursulas[ursula_id]
 
 
+class Enrique(Character):
+    pass
+
+
 class Ursula(Character, ProxyRESTServer):
     _server_class = NuCypherDHTServer
     _alice_class = Alice

--- a/nkms/crypto/api.py
+++ b/nkms/crypto/api.py
@@ -133,10 +133,12 @@ def generate_self_signed_certificate(common_name, curve, private_key=None, days_
 
 def encrypt_and_sign(recipient_pubkey_enc: UmbralPublicKey,
                     plaintext: bytes,
-                    signer: Union["SignatureStamp", None],
+                    signer: Union["SignatureStamp", "_Constant"],
                     sign_plaintext=True,
                     ) -> tuple:
-    if signer:
+
+    if signer is not constants.DO_NOT_SIGN:
+        # The caller didn't expressly tell us not to sign; we'll sign.
         if sign_plaintext:
             # Sign first, encrypt second.
             sig_header = constants.SIGNATURE_TO_FOLLOW

--- a/nkms/crypto/api.py
+++ b/nkms/crypto/api.py
@@ -147,10 +147,14 @@ def encrypt_and_sign(recipient_pubkey_enc: UmbralPublicKey,
             sig_header = constants.SIGNATURE_IS_ON_CIPHERTEXT
             ciphertext, capsule = pre.encrypt(recipient_pubkey_enc, sig_header + plaintext)
             signature = signer(ciphertext)
+        message_kit = UmbralMessageKit(ciphertext=ciphertext, capsule=capsule,
+                                       sender_pubkey_sig=signer.as_umbral_pubkey(),
+                                       signature=signature)
     else:
         # Don't sign.
         signature = sig_header = constants.NOT_SIGNED
         alice_pubkey = None
         ciphertext, capsule = pre.encrypt(recipient_pubkey_enc, sig_header + plaintext)
-    message_kit = UmbralMessageKit(ciphertext=ciphertext, capsule=capsule, sender_pubkey=signer)
+        message_kit = UmbralMessageKit(ciphertext=ciphertext, capsule=capsule)
+
     return message_kit, signature

--- a/nkms/crypto/kits.py
+++ b/nkms/crypto/kits.py
@@ -24,10 +24,10 @@ class MessageKit(CryptoKit):
 
     _signature = constants.NOT_SIGNED
 
-    def __init__(self, capsule, alice_pubkey=None, ciphertext=None):
+    def __init__(self, capsule, sender_pubkey=None, ciphertext=None):
         self.ciphertext = ciphertext
         self.capsule = capsule
-        self.alice_pubkey = alice_pubkey
+        self.sender_pubkey = sender_pubkey
 
     def to_bytes(self, include_alice_pubkey=True):
         # We include the capsule first.
@@ -35,8 +35,8 @@ class MessageKit(CryptoKit):
 
         # Then, before the ciphertext, we see if we're including alice's public key.
         # We want to put that first because it's typically of known length.
-        if include_alice_pubkey and self.alice_pubkey:
-            as_bytes += bytes(self.alice_pubkey)
+        if include_alice_pubkey and self.sender_pubkey:
+            as_bytes += bytes(self.sender_pubkey)
 
         as_bytes += self.ciphertext
         return as_bytes

--- a/nkms/crypto/kits.py
+++ b/nkms/crypto/kits.py
@@ -22,12 +22,11 @@ class CryptoKit:
 
 class MessageKit(CryptoKit):
 
-    _signature = constants.NOT_SIGNED
-
-    def __init__(self, capsule, sender_pubkey=None, ciphertext=None):
+    def __init__(self, capsule, sender_pubkey_sig=None, ciphertext=None, signature=constants.NOT_SIGNED):
         self.ciphertext = ciphertext
         self.capsule = capsule
-        self.sender_pubkey = sender_pubkey
+        self.sender_pubkey_sig = sender_pubkey_sig
+        self._signature = signature
 
     def to_bytes(self, include_alice_pubkey=True):
         # We include the capsule first.
@@ -35,8 +34,8 @@ class MessageKit(CryptoKit):
 
         # Then, before the ciphertext, we see if we're including alice's public key.
         # We want to put that first because it's typically of known length.
-        if include_alice_pubkey and self.sender_pubkey:
-            as_bytes += bytes(self.sender_pubkey)
+        if include_alice_pubkey and self.sender_pubkey_sig:
+            as_bytes += bytes(self.sender_pubkey_sig)
 
         as_bytes += self.ciphertext
         return as_bytes
@@ -51,3 +50,7 @@ class MessageKit(CryptoKit):
 
 class UmbralMessageKit(MessageKit):
     splitter = capsule_splitter + key_splitter
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.policy_pubkey = None

--- a/nkms/crypto/powers.py
+++ b/nkms/crypto/powers.py
@@ -114,7 +114,7 @@ class EncryptingPower(KeyPairBasedPower):
 
 
 class DelegatingPower(KeyPairBasedPower):   
-    _keypair_class = SigningKeypair
-    not_found_error = NoSigningPower
+    _keypair_class = EncryptingKeypair
+    not_found_error = PowerUpError
     provides = ("generate_kfrags",)
 

--- a/nkms/crypto/powers.py
+++ b/nkms/crypto/powers.py
@@ -62,6 +62,7 @@ class CryptoPowerUp(object):
 
 
 class KeyPairBasedPower(CryptoPowerUp):
+    confers_public_key = True
     _keypair_class = keypairs.Keypair
 
     def __init__(self,
@@ -101,14 +102,19 @@ class KeyPairBasedPower(CryptoPowerUp):
 
 
 class SigningPower(KeyPairBasedPower):
-    confers_public_key = True
     _keypair_class = SigningKeypair
     not_found_error = NoSigningPower
     provides = ("sign", "generate_self_signed_cert")
 
 
 class EncryptingPower(KeyPairBasedPower):
-    confers_public_key = True
     _keypair_class = EncryptingKeypair
     not_found_error = NoEncryptingPower
-    provides = ("decrypt", "generate_kfrags")
+    provides = ("decrypt",)
+
+
+class DelegatingPower(KeyPairBasedPower):   
+    _keypair_class = SigningKeypair
+    not_found_error = NoSigningPower
+    provides = ("generate_kfrags",)
+

--- a/nkms/crypto/signature.py
+++ b/nkms/crypto/signature.py
@@ -111,3 +111,13 @@ class SignatureStamp(object):
         :return: Hexdigest fingerprint of key (keccak-256) in bytes
         """
         return keccak_digest(bytes(self)).hex().encode()
+
+
+class StrangerStamp(SignatureStamp):
+    """
+    SignatureStamp of a stranger (ie, can only be used to glean public key, not to sign)
+    """
+
+    def __call__(self, *args, **kwargs):
+        message = "This isn't your SignatureStamp; it belongs to (a Stranger).  You can't sign with it."
+        raise TypeError(message)

--- a/nkms/crypto/signature.py
+++ b/nkms/crypto/signature.py
@@ -1,6 +1,8 @@
 from nkms.crypto import api as API
 from umbral.keys import UmbralPublicKey
 from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature, encode_dss_signature
+from nkms.crypto.api import keccak_digest
+from bytestring_splitter import BytestringSplitter
 
 
 class Signature(object):
@@ -59,3 +61,60 @@ class Signature(object):
     def __eq__(self, other):
         # TODO: Consider constant time
         return bytes(self) == bytes(other) or self._der_encoded_bytes() == other
+
+
+signature_splitter = BytestringSplitter(Signature)
+
+
+class SignatureStamp(object):
+    """
+    Can be called to sign something or used to express the signing public
+    key as bytes.
+    """
+
+    def __init__(self, character):
+        self.character = character
+
+    def __call__(self, *args, **kwargs):
+        return self.character.sign(*args, **kwargs)
+
+    def __bytes__(self):
+        from nkms.crypto.powers import SigningPower
+        return bytes(self.character.public_key(SigningPower))
+
+    def __hash__(self):
+        return int.from_bytes(self, byteorder="big")
+
+    def __eq__(self, other):
+        return other == bytes(self)
+
+    def __add__(self, other):
+        return bytes(self) + other
+
+    def __radd__(self, other):
+        return other + bytes(self)
+
+    def __len__(self):
+        return len(bytes(self))
+
+    def as_umbral_pubkey(self):
+        from nkms.crypto.powers import SigningPower
+        return self.character.public_key(SigningPower)
+
+    def fingerprint(self):
+        """
+        Hashes the key using keccak-256 and returns the hexdigest in bytes.
+
+        :return: Hexdigest fingerprint of key (keccak-256) in bytes
+        """
+        return keccak_digest(bytes(self)).hex().encode()
+
+
+class StrangerStamp(SignatureStamp):
+    """
+    SignatureStamp of a stranger (ie, can only be used to glean public key, not to sign)
+    """
+
+    def __call__(self, *args, **kwargs):
+        message = "This isn't your SignatureStamp; it belongs to {} (a Stranger).  You can't sign with it."
+        raise TypeError(message.format(self.character))

--- a/nkms/crypto/splitters.py
+++ b/nkms/crypto/splitters.py
@@ -5,6 +5,6 @@ from umbral.pre import Capsule
 from nkms.crypto.signature import Signature
 
 
-key_splitter = BytestringSplitter((UmbralPublicKey, PUBLIC_KEY_LENGTH, {"as_b64": False}))
+key_splitter = BytestringSplitter((UmbralPublicKey, PUBLIC_KEY_LENGTH))
 capsule_splitter = BytestringSplitter((Capsule, CAPSULE_LENGTH))
 signature_splitter = BytestringSplitter(Signature)

--- a/nkms/crypto/splitters.py
+++ b/nkms/crypto/splitters.py
@@ -2,9 +2,8 @@ from nkms.crypto.constants import PUBLIC_KEY_LENGTH, CAPSULE_LENGTH
 from bytestring_splitter import BytestringSplitter
 from umbral.keys import UmbralPublicKey
 from umbral.pre import Capsule
-from nkms.crypto.signature import Signature
 
 
 key_splitter = BytestringSplitter((UmbralPublicKey, PUBLIC_KEY_LENGTH))
 capsule_splitter = BytestringSplitter((Capsule, CAPSULE_LENGTH))
-signature_splitter = BytestringSplitter(Signature)
+

--- a/nkms/data_sources.py
+++ b/nkms/data_sources.py
@@ -1,17 +1,14 @@
 from nkms.crypto.api import encrypt_and_sign
-from nkms.crypto.kits import MessageKit
-from umbral import pre
-from nkms.crypto.powers import EncryptingPower
+from nkms.crypto.powers import DelegatingPower
 
 
 class DataSource:
 
-    def __init__(self, policy):
-        self._policy_key = policy.alice.public_key(EncryptingPower)
+    def __init__(self, policy, signer):
+        self._policy_key = policy.alice.public_key(DelegatingPower)
+        self.stamp = signer
 
     def encapsulate_single_message(self, message):
-        encrypt_and_sign(self._policy_key, plaintext=message, signer=None)
-        ciphertext, capsule = pre.encrypt(self._policy_key, message)
-        return MessageKit(ciphertext=ciphertext,
-                          capsule=capsule,
-                          sender_pubkey=self._policy_key)
+        message_kit, signature = encrypt_and_sign(self._policy_key, plaintext=message, signer=self.stamp)
+        message_kit.policy_pubkey = self._policy_key  # TODO: We can probably do better here.
+        return message_kit, signature

--- a/nkms/data_sources.py
+++ b/nkms/data_sources.py
@@ -1,0 +1,17 @@
+from nkms.crypto.api import encrypt_and_sign
+from nkms.crypto.kits import MessageKit
+from umbral import pre
+from nkms.crypto.powers import EncryptingPower
+
+
+class DataSource:
+
+    def __init__(self, policy):
+        self._policy_key = policy.alice.public_key(EncryptingPower)
+
+    def encapsulate_single_message(self, message):
+        encrypt_and_sign(self._policy_key, plaintext=message, signer=None)
+        ciphertext, capsule = pre.encrypt(self._policy_key, message)
+        return MessageKit(ciphertext=ciphertext,
+                          capsule=capsule,
+                          sender_pubkey=self._policy_key)

--- a/nkms/data_sources.py
+++ b/nkms/data_sources.py
@@ -1,14 +1,15 @@
 from nkms.crypto.api import encrypt_and_sign
-from nkms.crypto.powers import DelegatingPower
 
 
 class DataSource:
 
-    def __init__(self, policy, signer):
-        self._policy_key = policy.alice.public_key(DelegatingPower)
+    def __init__(self, policy_pubkey_enc, signer):
+        self._policy_pubkey_enc = policy_pubkey_enc
         self.stamp = signer
 
     def encapsulate_single_message(self, message):
-        message_kit, signature = encrypt_and_sign(self._policy_key, plaintext=message, signer=self.stamp)
-        message_kit.policy_pubkey = self._policy_key  # TODO: We can probably do better here.
+        message_kit, signature = encrypt_and_sign(self._policy_pubkey_enc,
+                                                  plaintext=message,
+                                                  signer=self.stamp)
+        message_kit.policy_pubkey = self._policy_pubkey_enc  # TODO: We can probably do better here.
         return message_kit, signature

--- a/nkms/keystore/keypairs.py
+++ b/nkms/keystore/keypairs.py
@@ -76,7 +76,7 @@ class EncryptingKeypair(Keypair):
         cleartext = pre.decrypt(ciphertext=message_kit.ciphertext,
                                 capsule=message_kit.capsule,
                                 priv_key=self._privkey,
-                                alice_pub_key=message_kit.alice_pubkey)
+                                alice_pub_key=message_kit.sender_pubkey)
 
         return cleartext
 

--- a/nkms/keystore/keypairs.py
+++ b/nkms/keystore/keypairs.py
@@ -76,7 +76,7 @@ class EncryptingKeypair(Keypair):
         cleartext = pre.decrypt(ciphertext=message_kit.ciphertext,
                                 capsule=message_kit.capsule,
                                 priv_key=self._privkey,
-                                alice_pub_key=message_kit.sender_pubkey)
+                                alice_pub_key=message_kit.policy_pubkey)
 
         return cleartext
 
@@ -114,6 +114,5 @@ class SigningKeypair(Keypair):
         return Signature.from_bytes(signature_der_bytes, der_encoded=True)
 
     def generate_self_signed_cert(self, common_name):
-        # TODO: Let's have a shortcut method for getting the cryptography key(s).
         cryptography_key = self._privkey.to_cryptography_privkey()
         return generate_self_signed_certificate(common_name, default_curve(), cryptography_key)

--- a/nkms/keystore/keystore.py
+++ b/nkms/keystore/keystore.py
@@ -70,7 +70,7 @@ class KeyStore(object):
             raise NotFound(
                 "No key with fingerprint {} found.".format(fingerprint))
 
-        pubkey = UmbralPublicKey.from_bytes(key.key_data, as_b64=False)
+        pubkey = UmbralPublicKey.from_bytes(key.key_data)
         return pubkey
 
     def del_key(self, fingerprint: bytes, session=None):

--- a/nkms/network/protocols.py
+++ b/nkms/network/protocols.py
@@ -12,7 +12,7 @@ from nkms.network.routing import NuCypherRoutingTable
 from umbral.keys import UmbralPublicKey
 
 dht_value_splitter = default_constant_splitter + BytestringSplitter(Signature,
-                                        (UmbralPublicKey, PUBLIC_KEY_LENGTH, {"as_b64": False}),
+                                        (UmbralPublicKey, PUBLIC_KEY_LENGTH),
                                         (bytes, KECCAK_DIGEST_LENGTH))
 
 

--- a/nkms/network/server.py
+++ b/nkms/network/server.py
@@ -198,7 +198,7 @@ class ProxyRESTServer(object):
         # group_payload_splitter = BytestringSplitter(PublicKey)
         # policy_payload_splitter = BytestringSplitter((KFrag, KFRAG_LENGTH))
 
-        alice = self._alice_class.from_public_keys({SigningPower: policy_message_kit.alice_pubkey})
+        alice = self._alice_class.from_public_keys({SigningPower: policy_message_kit.sender_pubkey})
 
         verified, cleartext = self.verify_from(alice, policy_message_kit, decrypt=True)
 

--- a/nkms/network/server.py
+++ b/nkms/network/server.py
@@ -198,7 +198,7 @@ class ProxyRESTServer(object):
         # group_payload_splitter = BytestringSplitter(PublicKey)
         # policy_payload_splitter = BytestringSplitter((KFrag, KFRAG_LENGTH))
 
-        alice = self._alice_class.from_public_keys({SigningPower: policy_message_kit.sender_pubkey})
+        alice = self._alice_class.from_public_keys({SigningPower: policy_message_kit.sender_pubkey_sig})
 
         verified, cleartext = self.verify_from(alice, policy_message_kit, decrypt=True)
 

--- a/nkms/policy/models.py
+++ b/nkms/policy/models.py
@@ -11,7 +11,7 @@ from nkms.characters import Alice
 from nkms.characters import Bob, Ursula
 from nkms.crypto.api import keccak_digest
 from nkms.crypto.constants import KECCAK_DIGEST_LENGTH
-from nkms.crypto.powers import SigningPower
+from nkms.crypto.powers import SigningPower, DelegatingPower
 from nkms.crypto.signature import Signature
 from nkms.crypto.splitters import key_splitter
 from bytestring_splitter import BytestringSplitter
@@ -271,6 +271,8 @@ class Policy(object):
                 arrangement.publish(kfrag, ursula, result)
                 # TODO: What if there weren't enough Arrangements approved to distribute n kfrags?  We need to raise NotEnoughQualifiedUrsulas.
 
+    def public_key(self):
+        return self.alice.public_key(DelegatingPower)
 
 class TreasureMap(object):
     def __init__(self, ursula_interface_ids=None):

--- a/tests/characters/test_alice_can_grant_and_revoke.py
+++ b/tests/characters/test_alice_can_grant_and_revoke.py
@@ -46,8 +46,8 @@ def test_alice_can_get_ursulas_keys_via_rest(alice, ursulas):
     mock_client = TestClient(ursulas[0].rest_app)
     response = mock_client.get('http://localhost/public_keys')
     splitter = BytestringSplitter(
-        (UmbralPublicKey, PUBLIC_KEY_LENGTH, {"as_b64": False}),
-        (UmbralPublicKey, PUBLIC_KEY_LENGTH, {"as_b64": False})
+        (UmbralPublicKey, PUBLIC_KEY_LENGTH),
+        (UmbralPublicKey, PUBLIC_KEY_LENGTH)
     )
     signing_key, encrypting_key = splitter(response.content)
     stranger_ursula_from_public_keys = Ursula.from_public_keys({SigningPower: signing_key,

--- a/tests/characters/test_bob_handles_frags.py
+++ b/tests/characters/test_bob_handles_frags.py
@@ -137,7 +137,7 @@ def test_bob_remembers_that_he_has_cfrags_for_a_particular_capsule(enacted_polic
     capsule_side_channel.capsule.attach_cfrag(new_cfrag)
 
 
-def test_bob_gathers_and_combines(enacted_policy, alice, bob, ursulas, capsule_side_channel):
+def test_bob_gathers_and_combines(enacted_policy, bob, ursulas, capsule_side_channel):
     # Bob has saved two WorkOrders so far.
     assert len(bob._saved_work_orders) == 2
 

--- a/tests/characters/test_bob_handles_frags.py
+++ b/tests/characters/test_bob_handles_frags.py
@@ -26,7 +26,7 @@ def test_bob_can_follow_treasure_map(enacted_policy, ursulas, alice, bob):
 
 
 def test_bob_can_issue_a_work_order_to_a_specific_ursula(enacted_policy, alice, bob, ursulas,
-                                                         alicebob_side_channel):
+                                                         capsule_side_channel):
     """
     Now that Bob has his list of Ursulas, he can issue a WorkOrder to one.  Upon receiving the WorkOrder, Ursula
     saves it and responds by re-encrypting and giving Bob a cFrag.
@@ -48,7 +48,7 @@ def test_bob_can_issue_a_work_order_to_a_specific_ursula(enacted_policy, alice, 
 
     # We'll test against just a single Ursula - here, we make a WorkOrder for just one.
     # We can pass any number of capsules as args; here we pass just one.
-    work_orders = bob.generate_work_orders(the_hrac, alicebob_side_channel.capsule, num_ursulas=1)
+    work_orders = bob.generate_work_orders(the_hrac, capsule_side_channel.capsule, num_ursulas=1)
 
     # Again: one Ursula, one work_order.
     assert len(work_orders) == 1
@@ -72,7 +72,7 @@ def test_bob_can_issue_a_work_order_to_a_specific_ursula(enacted_policy, alice, 
     the_cfrag = cfrags[0]
 
     # Attach the CFrag to the Capsule.
-    alicebob_side_channel.capsule.attach_cfrag(the_cfrag)
+    capsule_side_channel.capsule.attach_cfrag(the_cfrag)
 
     # Having received the cFrag, Bob also saved the WorkOrder as complete.
     assert len(bob._saved_work_orders) == 1
@@ -83,7 +83,7 @@ def test_bob_can_issue_a_work_order_to_a_specific_ursula(enacted_policy, alice, 
     kfrag_bytes = ursula.datastore.get_policy_arrangement(
         work_order.kfrag_hrac.hex().encode()).k_frag
     the_kfrag = KFrag.from_bytes(kfrag_bytes)
-    the_correct_cfrag = pre.reencrypt(the_kfrag, alicebob_side_channel.capsule)
+    the_correct_cfrag = pre.reencrypt(the_kfrag, capsule_side_channel.capsule)
     assert bytes(the_cfrag) == bytes(the_correct_cfrag)  # It's the correct cfrag!
 
     # Now we'll show that Ursula saved the correct WorkOrder.
@@ -93,14 +93,14 @@ def test_bob_can_issue_a_work_order_to_a_specific_ursula(enacted_policy, alice, 
 
 
 def test_bob_remembers_that_he_has_cfrags_for_a_particular_capsule(enacted_policy, alice, bob,
-                                                                   ursulas, alicebob_side_channel):
+                                                                   ursulas, capsule_side_channel):
     # In our last episode, Bob made a WorkOrder for the capsule...
-    assert len(bob._saved_work_orders.by_capsule(alicebob_side_channel.capsule)) == 1
+    assert len(bob._saved_work_orders.by_capsule(capsule_side_channel.capsule)) == 1
     # ...and he used it to obtain a CFrag from Ursula.
-    assert len(alicebob_side_channel.capsule._attached_cfrags) == 1
+    assert len(capsule_side_channel.capsule._attached_cfrags) == 1
 
     # He can also get a dict of {Ursula:WorkOrder} by looking them up from the capsule.
-    workorders_by_capsule = bob._saved_work_orders.by_capsule(alicebob_side_channel.capsule)
+    workorders_by_capsule = bob._saved_work_orders.by_capsule(capsule_side_channel.capsule)
 
     # Bob has just one WorkOrder from that one Ursula.
     assert len(workorders_by_capsule) == 1
@@ -108,7 +108,7 @@ def test_bob_remembers_that_he_has_cfrags_for_a_particular_capsule(enacted_polic
 
     # The rest of this test will show that if Bob generates another WorkOrder, it's for a *different* Ursula.
     generated_work_orders = bob.generate_work_orders(enacted_policy.hrac(),
-                                                     alicebob_side_channel.capsule,
+                                                     capsule_side_channel.capsule,
                                                      num_ursulas=1)
     id_of_this_new_ursula, new_work_order = list(generated_work_orders.items())[0]
 
@@ -134,10 +134,10 @@ def test_bob_remembers_that_he_has_cfrags_for_a_particular_capsule(enacted_polic
     new_cfrag = cfrags[0]
 
     # Attach the CFrag to the Capsule.
-    alicebob_side_channel.capsule.attach_cfrag(new_cfrag)
+    capsule_side_channel.capsule.attach_cfrag(new_cfrag)
 
 
-def test_bob_gathers_and_combines(enacted_policy, alice, bob, ursulas, alicebob_side_channel):
+def test_bob_gathers_and_combines(enacted_policy, alice, bob, ursulas, capsule_side_channel):
     # Bob has saved two WorkOrders so far.
     assert len(bob._saved_work_orders) == 2
 
@@ -146,12 +146,12 @@ def test_bob_gathers_and_combines(enacted_policy, alice, bob, ursulas, alicebob_
 
     # Bob can't decrypt yet with just two CFrags.  He needs to gather at least m.
     with pytest.raises(pre.GenericUmbralError):
-        bob.decrypt(alicebob_side_channel)
+        bob.decrypt(capsule_side_channel)
 
     number_left_to_collect = enacted_policy.m - len(bob._saved_work_orders)
 
     new_work_orders = bob.generate_work_orders(enacted_policy.hrac(),
-                                               alicebob_side_channel.capsule,
+                                               capsule_side_channel.capsule,
                                                num_ursulas=number_left_to_collect)
     _id_of_yet_another_ursula, new_work_order = list(new_work_orders.items())[0]
 
@@ -159,8 +159,8 @@ def test_bob_gathers_and_combines(enacted_policy, alice, bob, ursulas, alicebob_
     # In the real world, we'll have a full Ursula node here.  But in this case, we need to fake it.
     new_work_order.ursula = ursulas[2]
     cfrags = bob.get_reencrypted_c_frags(networky_stuff, new_work_order)
-    alicebob_side_channel.capsule.attach_cfrag(cfrags[0])
+    capsule_side_channel.capsule.attach_cfrag(cfrags[0])
 
     # Now.
     # At long last.
-    assert bob.decrypt(alicebob_side_channel) == b'Welcome to the flippering.'
+    assert bob.decrypt(capsule_side_channel) == b'Welcome to the flippering.'

--- a/tests/characters/test_crypto_characters_and_their_powers.py
+++ b/tests/characters/test_crypto_characters_and_their_powers.py
@@ -22,11 +22,9 @@ def test_actor_without_signing_power_cannot_sign():
     with pytest.raises(NoSigningPower) as e_info:
         non_signer.stamp("something")
 
-    # ...or as a way to cast the public key to bytes or tuple.
+    # ...or as a way to cast the (non-existent) public key to bytes.
     with pytest.raises(NoSigningPower) as e_info:
         bytes(non_signer.stamp)
-    with pytest.raises(NoSigningPower) as e_info:
-        tuple(non_signer.stamp)
 
 
 def test_actor_with_signing_power_can_sign():

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -90,8 +90,9 @@ def test_keystore():
 
 
 @pytest.fixture(scope="module")
-def capsule_side_channel(alice, enacted_policy):
+def capsule_side_channel(enacted_policy):
     signing_keypair = SigningKeypair()
-    data_source = DataSource(policy=enacted_policy, signer=SignatureStamp(signing_keypair))
+    data_source = DataSource(policy_pubkey_enc=enacted_policy.public_key(),
+                             signer=SignatureStamp(signing_keypair))
     message_kit, _signature = data_source.encapsulate_single_message(b"Welcome to the flippering.")
     return message_kit, data_source

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -3,9 +3,9 @@ import os
 import pytest
 
 from constant_sorrow import constants
-from nkms.characters import Alice, Bob
+from nkms.characters import Alice, Bob, Enrique
 from nkms.crypto.kits import MessageKit
-from nkms.crypto.powers import SigningPower, EncryptingPower
+from nkms.crypto.powers import SigningPower, EncryptingPower, DelegatingPower
 from nkms.network import blockchain_client
 from tests.utilities import NUMBER_OF_URSULAS_IN_NETWORK, MockNetworkyStuff, make_ursulas, \
     URSULA_PORT, EVENT_LOOP
@@ -19,18 +19,18 @@ import maya
 @pytest.fixture(scope="module")
 def idle_policy(alice, bob):
     """
-    Creates a PolicyGroup, in a manner typical of how Alice might do it, with a unique uri.
+    Creates a Policy, in a manner typical of how Alice might do it, with a unique uri (soon to be "label" - see #183)
     """
     alice.__resource_id += b"/unique-again"  # A unique name each time, like a path.
     n = NUMBER_OF_URSULAS_IN_NETWORK
 
-    policy_group = alice.create_policy(
+    policy = alice.create_policy(
         bob,
         alice.__resource_id,
         m=3,
         n=n,
     )
-    return policy_group
+    return policy
 
 
 @pytest.fixture(scope="module")
@@ -66,6 +66,11 @@ def bob():
 
 
 @pytest.fixture(scope="module")
+def enrique():
+    return Enrique()
+
+
+@pytest.fixture(scope="module")
 def ursulas():
     URSULAS = make_ursulas(NUMBER_OF_URSULAS_IN_NETWORK, URSULA_PORT)
     yield URSULAS
@@ -90,10 +95,10 @@ def test_keystore():
 
 
 @pytest.fixture(scope="module")
-def alicebob_side_channel(alice):
+def capsule_side_channel(alice):
     plaintext = b"Welcome to the flippering."
-    ciphertext, capsule = pre.encrypt(alice.public_key(EncryptingPower), plaintext)
+    ciphertext, capsule = pre.encrypt(alice.public_key(DelegatingPower), plaintext)
     return MessageKit(ciphertext=ciphertext, capsule=capsule,
-                      alice_pubkey=alice.public_key(EncryptingPower))
+                      alice_pubkey=alice.public_key(DelegatingPower))
 
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -58,7 +58,7 @@ def alice(ursulas):
 
 
 @pytest.fixture(scope="module")
-def bob(alice, ursulas):
+def bob():
     BOB = Bob()
     BOB.server.listen(8475)
     EVENT_LOOP.run_until_complete(BOB.server.bootstrap([("127.0.0.1", URSULA_PORT)]))
@@ -77,7 +77,7 @@ def ursulas():
 
 
 @pytest.fixture(scope="module")
-def treasure_map_is_set_on_dht(alice, enacted_policy):
+def treasure_map_is_set_on_dht(enacted_policy):
     enacted_policy.publish_treasure_map()
 
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -91,6 +91,8 @@ def test_keystore():
 
 
 @pytest.fixture(scope="module")
-def capsule_side_channel(enacted_policy):
-    data_source = DataSource(enacted_policy)
-    return data_source.encapsulate_single_message(b"Welcome to the flippering.")
+def capsule_side_channel(alice, enacted_policy):
+    signing_keypair = SigningKeypair()
+    data_source = DataSource(policy=enacted_policy, signer=SignatureStamp(signing_keypair))
+    message_kit, _signature = data_source.encapsulate_single_message(b"Welcome to the flippering.")
+    return message_kit, data_source

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -4,16 +4,15 @@ import pytest
 
 from constant_sorrow import constants
 from nkms.characters import Alice, Bob
-from nkms.crypto.kits import MessageKit
-from nkms.crypto.powers import DelegatingPower
+from nkms.crypto.signature import SignatureStamp
 from nkms.data_sources import DataSource
+from nkms.keystore.keypairs import SigningKeypair
 from nkms.network import blockchain_client
 from tests.utilities import NUMBER_OF_URSULAS_IN_NETWORK, MockNetworkyStuff, make_ursulas, \
     URSULA_PORT, EVENT_LOOP
 from sqlalchemy.engine import create_engine
 from nkms.keystore import keystore
 from nkms.keystore.db import Base
-from umbral import pre
 import maya
 
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -3,9 +3,10 @@ import os
 import pytest
 
 from constant_sorrow import constants
-from nkms.characters import Alice, Bob, Enrique
+from nkms.characters import Alice, Bob
 from nkms.crypto.kits import MessageKit
-from nkms.crypto.powers import SigningPower, EncryptingPower, DelegatingPower
+from nkms.crypto.powers import DelegatingPower
+from nkms.data_sources import DataSource
 from nkms.network import blockchain_client
 from tests.utilities import NUMBER_OF_URSULAS_IN_NETWORK, MockNetworkyStuff, make_ursulas, \
     URSULA_PORT, EVENT_LOOP
@@ -66,11 +67,6 @@ def bob():
 
 
 @pytest.fixture(scope="module")
-def enrique():
-    return Enrique()
-
-
-@pytest.fixture(scope="module")
 def ursulas():
     URSULAS = make_ursulas(NUMBER_OF_URSULAS_IN_NETWORK, URSULA_PORT)
     yield URSULAS
@@ -95,10 +91,6 @@ def test_keystore():
 
 
 @pytest.fixture(scope="module")
-def capsule_side_channel(alice):
-    plaintext = b"Welcome to the flippering."
-    ciphertext, capsule = pre.encrypt(alice.public_key(DelegatingPower), plaintext)
-    return MessageKit(ciphertext=ciphertext, capsule=capsule,
-                      alice_pubkey=alice.public_key(DelegatingPower))
-
-
+def capsule_side_channel(enacted_policy):
+    data_source = DataSource(enacted_policy)
+    return data_source.encapsulate_single_message(b"Welcome to the flippering.")

--- a/tests/network/test_network_actors.py
+++ b/tests/network/test_network_actors.py
@@ -5,7 +5,6 @@ import pytest
 from kademlia.utils import digest
 
 from constant_sorrow import constants
-from nkms.blockchain.eth.utilities import spawn_miners
 from nkms.crypto.api import keccak_digest
 from nkms.crypto.kits import UmbralMessageKit
 from nkms.network import blockchain_client


### PR DESCRIPTION
Alice can now `grant` and then disappear from the network, never to be seen again.

Subsequently, any number of `DataSources` can supply messages for `Bob`.

This is comparable to our discussions about a four-character narrative involving a `Character` named `Enrique` the Encapsulator (See #182).

However, once `Enrique` was written, it was clear that he *wasn't* a `Character`.  He didn't require any special powers (remember, his only notable role was to encrypt, which any `Character` can do).

Additionally, unlike the other characters in our cryptological narrative, `Enrique`'s exact interests are very hard to pin down: he doesn't pay, nor does he stake, nor does he rely on messages from the other actors.  In fact, his role is arguably optional: `Alice` *can* do everything he does.

So, `DataSource` now does what we imagined `Enrique` doing: signing messages and making `Capsules` our of them.

This PR closes #182 and gives finality to #218.

See what y'all think.